### PR TITLE
support windows import paths

### DIFF
--- a/src/cli/kvist/main.odin
+++ b/src/cli/kvist/main.odin
@@ -586,6 +586,53 @@ odin_output_executable_path :: proc(generated_abs: string) -> string {
     return strings.clone(fmt.tprintf("%s%s", generated_abs, suffix))
 }
 
+windows_import_collection_args :: proc(generated_path: string) -> [dynamic]string {
+    args: [dynamic]string
+    when ODIN_OS != .Windows {
+        return args
+    }
+
+    data, read_err := os.read_entire_file_from_path(generated_path, context.allocator)
+    if read_err != nil {
+        return args
+    }
+    defer delete(data)
+
+    seen: [26]bool
+    source := string(data)
+    line_start := 0
+    for i := 0; i <= len(source); i += 1 {
+        if i < len(source) && source[i] != '\n' {
+            continue
+        }
+        line := source[line_start:i]
+        line_start = i + 1
+        if !strings.has_prefix(line, "import ") {
+            continue
+        }
+        quote := strings.index(line, `"`)
+        if quote < 0 || quote+3 >= len(line) {
+            continue
+        }
+        drive := line[quote+1]
+        if drive >= 'a' && drive <= 'z' {
+            drive -= 'a'-'A'
+        }
+        if drive < 'A' || drive > 'Z' ||
+           line[quote+2] != ':' ||
+           (line[quote+3] != '/' && line[quote+3] != '\\') {
+            continue
+        }
+        drive_index := int(drive-'A')
+        if seen[drive_index] {
+            continue
+        }
+        seen[drive_index] = true
+        append(&args, fmt.tprintf("-collection:%c=%c:/", drive, drive))
+    }
+    return args
+}
+
 print_compile_warnings :: proc(path, source, eval_source: string, warnings: []kvist.Compile_Warning) {
     for warning, idx in warnings {
         if warning.confidence == .Conservative && !ownership_audit_enabled {
@@ -684,6 +731,11 @@ run_odin_file :: proc(command, generated_path, source_path, source, eval_source,
         append(&args, "odin", odin_command, package_arg)
     } else {
         append(&args, "odin", odin_command, generated_abs, "-file")
+    }
+    collection_args := windows_import_collection_args(generated_abs)
+    defer kvist.delete_string_slice(&collection_args)
+    for arg in collection_args {
+        append(&args, arg)
     }
     for arg in extra_args {
         append(&args, arg)

--- a/src/cli/kvist/main.odin
+++ b/src/cli/kvist/main.odin
@@ -628,7 +628,7 @@ windows_import_collection_args :: proc(generated_path: string) -> [dynamic]strin
             continue
         }
         seen[drive_index] = true
-        append(&args, fmt.tprintf("-collection:%c=%c:/", drive, drive))
+        append(&args, strings.clone(fmt.tprintf("-collection:%c=%c:/", drive, drive)))
     }
     return args
 }

--- a/src/odin/kvist/compiler.odin
+++ b/src/odin/kvist/compiler.odin
@@ -3643,7 +3643,8 @@ rebase_emitted_odin_imports :: proc(source, output_dir: string) -> (output: stri
                 rest := line[first_quote+1:]
                 second_quote := strings.index(rest, "\"")
                 if second_quote >= 0 {
-                    import_path := rest[:second_quote]
+                    import_path := unquote_string(line[first_quote:first_quote+second_quote+2])
+                    defer delete(import_path)
                     if os.is_absolute_path(import_path) {
                         canonical_import_path, import_path_err := os.get_absolute_path(import_path, context.allocator)
                         if import_path_err != nil {

--- a/tests/compiler_test.odin
+++ b/tests/compiler_test.odin
@@ -25206,6 +25206,17 @@ compile_output_rebases_absolute_odin_imports_for_output_path :: proc(t: ^testing
 
     testing.expect_value(t, strings.contains(rebased, "import runtime "), true)
     testing.expect_value(t, strings.contains(rebased, "import runtime \"/"), false)
+    import_prefix := `import runtime "`
+    import_start := strings.index(rebased, import_prefix)
+    testing.expect_value(t, import_start >= 0, true)
+    if import_start >= 0 {
+        path_start := import_start + len(import_prefix)
+        path_end_offset := strings.index(rebased[path_start:], `"`)
+        testing.expect_value(t, path_end_offset >= 0, true)
+        if path_end_offset >= 0 {
+            testing.expect_value(t, os.is_absolute_path(rebased[path_start:path_start+path_end_offset]), false)
+        }
+    }
 }
 
 @(test)


### PR DESCRIPTION
## summary
- decode quoted absolute imports before rebasing generated Odin
- add Odin collections for cross-drive Windows imports
- retain owned collection arguments through process launch
- merge the fixes with current Kvist `main` so Vev can pin one compiler revision for all platforms

## verification
- `odin test tests -all-packages` (752 tests)
- optimized Kvist CLI build
- Vev release gate run 29638673757 passed macOS arm64, Linux x86-64, Windows x86-64, and the combined release with revision 2ae21627
